### PR TITLE
Add Variable Step Size to BFGS

### DIFF
--- a/BFGS/bfgs.cpp
+++ b/BFGS/bfgs.cpp
@@ -2,8 +2,7 @@
 #include <iostream>
 #include <cmath>
 #include <fstream>
-#include "../test/testfun.hpp"
-#include <Eigen/Dense>
+#include<Eigen/Dense>
 #include <iomanip>
 #include "../testfun.hpp"
 
@@ -11,7 +10,6 @@ using namespace std;
 
 template<typename ObjFunc> // Use the parameter 'max_bound' to define edge of hypercube to optimse in
 Eigen::VectorXd bfgs(ObjFunc f, const int max_iter, const Eigen::VectorXd& int_val,
-  const double rel_sol_change_tol, const double grad_nrm_tol, const double gam,
   const double rel_sol_change_tol, const double grad_nrm_tol, double gam,
    const double max_bound){
     // Initialise vectors to hold xk, xk+1 and print initial value.
@@ -22,7 +20,6 @@ Eigen::VectorXd bfgs(ObjFunc f, const int max_iter, const Eigen::VectorXd& int_v
     Eigen::VectorXd df_prev(dim), df(dim), s(dim), q(dim), w(dim);
 
     // Useful constants for updates
-    double st_q, qt_d_q;
     double st_q, qt_D_q;
 
     // Initialise relative changes to large number
@@ -30,20 +27,12 @@ Eigen::VectorXd bfgs(ObjFunc f, const int max_iter, const Eigen::VectorXd& int_v
     double grad_nrm = 2*grad_nrm_tol;
 
     // Initialise matrix D as the identity matrix
-    Eigen::MatrixXd d = Eigen::MatrixXd::Identity(dim, dim);
     Eigen::MatrixXd D = Eigen::MatrixXd::Identity(dim, dim);
 
     int iter = 0;  // Initial no. iterations
 
     // Compute initial gradient
     df_prev = f.gradient(step_prev);
-
-    // While max iteraitons has not been reached and all change tolerances have
-    // not been met, perform bfgs update
-    while (iter < max_iter && rel_sol_change > rel_sol_change_tol && grad_nrm > grad_nrm_tol){
-      // Update step
-      step = step_prev - gam*d*df_prev;
-
     grad_nrm = df_prev.norm();
     // While max iteraitons has not been reached and all change tolerances have
     // not been met, perform bfgs update
@@ -74,9 +63,6 @@ Eigen::VectorXd bfgs(ObjFunc f, const int max_iter, const Eigen::VectorXd& int_v
 
       // Update the matrix d
       st_q = s.transpose()*q;
-      qt_d_q = abs(q.transpose()*d*q); // Small values may cause erratic negative values
-      w = sqrt(qt_d_q)*(s/st_q - d*q/qt_d_q);
-      d += s*s.transpose()/st_q - d*q*q.transpose()*d/qt_d_q + w*w.transpose();
       qt_D_q = abs(q.transpose()*D*q); // Small values may cause erratic negative values
       w = sqrt(qt_D_q)*(s/st_q - D*q/qt_D_q);
       D += s*s.transpose()/st_q - D*q*q.transpose()*D/qt_D_q + w*w.transpose();
@@ -85,25 +71,25 @@ Eigen::VectorXd bfgs(ObjFunc f, const int max_iter, const Eigen::VectorXd& int_v
       df_prev = df;
       ++iter;
     }
+    // cout << "gamma is" << gamma << endl;
     return step;
   }
 
 int main (){
-  const int d = 2, max_iter = pow(10, 1);  // Dimensionality and max iterations
-  double gam = 0.01; // Learning rate
+  const int d = 2, max_iter = pow(10, 2);  // Dimensionality and max iterations
+  double gam = 0.001; // Learning rate
   Eggholder f(d); // Define problem function
   double max_bound = 512;  // domain boundaries
   // Set convergence tolerances
-  double grad_nrm_tol = pow(10,-10), rel_sol_change_tol = pow(10,-10);
+  double grad_nrm_tol = pow(10,-8), rel_sol_change_tol = pow(10,-8);
 
   double minimum_f = pow(10,10), f_temp;  // Store the min f over all runs (f_temp used as placeholder below)
   Eigen::VectorXd overall_min(d);  // Store the minimum point over all runs
 
-  for (int n=0; n<100000; ++n){  // loop for many values of n
+  for (int n=0; n<10000; ++n){  // loop for many values of n
     // Create vectors to hold initial and final values
     Eigen::VectorXd int_val(d), min_val(d);
     int_val = max_bound*Eigen::MatrixXd::Random(d,1); // Set initial point
-
 
     min_val = bfgs(f, max_iter, int_val, rel_sol_change_tol, grad_nrm_tol, gam, max_bound);
 
@@ -116,8 +102,11 @@ int main (){
       "new minimum point:\n " << min_val << "\n function value: " << f_temp <<"\n";
     }
   }
-  Eigen::VectorXd min_val = bfgs(f, 1000*max_iter, overall_min, rel_sol_change_tol, grad_nrm_tol, gam, max_bound);
+  Eigen::VectorXd mini_val(d);
+  grad_nrm_tol = pow(10,-10), rel_sol_change_tol = pow(10,-8);
+  mini_val = bfgs(f, 1000*max_iter, overall_min, rel_sol_change_tol, grad_nrm_tol, gam, max_bound);
+
   cout << "\n----------------------------------\n";
-  cout << "\nThe global minimiser found was :\n" << min_val <<"\n with a function value of: " << minimum_f << "\n";
+  cout << "\nThe global minimiser found was :\n" << std::setprecision(9) << mini_val <<"\n with a function value of: " << minimum_f << "\n";
   return 0;
 }


### PR DESCRIPTION
Do an inexact line search using the [Armijo rule](https://en.wikipedia.org/wiki/Wolfe_conditions) to set step size